### PR TITLE
Log stuff ourselves

### DIFF
--- a/src/api/server.go
+++ b/src/api/server.go
@@ -12,6 +12,9 @@ func Server() (e *echo.Echo) {
 
 	// Allow browser clients to use the API
 	e.Use(middleware.CORS())
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+	}))
 
 	v1.API(e.Group("/v1"))
 

--- a/src/api/server.go
+++ b/src/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	v1 "github.com/ImpactDevelopment/ImpactServer/src/api/v1"
+	mid "github.com/ImpactDevelopment/ImpactServer/src/middleware"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -12,9 +13,7 @@ func Server() (e *echo.Echo) {
 
 	// Allow browser clients to use the API
 	e.Use(middleware.CORS())
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
-	}))
+	e.Use(mid.Log)
 
 	v1.API(e.Group("/v1"))
 

--- a/src/middleware/log.go
+++ b/src/middleware/log.go
@@ -3,5 +3,5 @@ package middleware
 import "github.com/labstack/echo/v4/middleware"
 
 var Log = middleware.LoggerWithConfig(middleware.LoggerConfig{
-	Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+	Format: "${status} ${method} ${host}${uri} latency=${latency_human} error=${error}\n",
 })

--- a/src/middleware/log.go
+++ b/src/middleware/log.go
@@ -1,0 +1,7 @@
+package middleware
+
+import "github.com/labstack/echo/v4/middleware"
+
+var Log = middleware.LoggerWithConfig(middleware.LoggerConfig{
+	Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+})

--- a/src/newWeb/server.go
+++ b/src/newWeb/server.go
@@ -1,6 +1,7 @@
 package newWeb
 
 import (
+	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 	"net/url"
 
@@ -12,6 +13,10 @@ import (
 
 func Server() (e *echo.Echo) {
 	e = echo.New()
+
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+	}))
 
 	e.GET("/ImpactInstaller.*", redirect(http.StatusFound, "https://impactclient.net/"), mid.NoCache())
 	e.Any("/*", proxy("https://impact-web.herokuapp.com/"))

--- a/src/newWeb/server.go
+++ b/src/newWeb/server.go
@@ -1,7 +1,6 @@
 package newWeb
 
 import (
-	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 	"net/url"
 
@@ -14,9 +13,7 @@ import (
 func Server() (e *echo.Echo) {
 	e = echo.New()
 
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
-	}))
+	e.Use(mid.Log)
 
 	e.GET("/ImpactInstaller.*", redirect(http.StatusFound, "https://impactclient.net/"), mid.NoCache())
 	e.Any("/*", proxy("https://impact-web.herokuapp.com/"))

--- a/src/s3proxy/server.go
+++ b/src/s3proxy/server.go
@@ -1,6 +1,7 @@
 package s3proxy
 
 import (
+	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 	"net/url"
 	"time"
@@ -17,6 +18,10 @@ var AWSSession = session.Must(session.NewSession(&aws.Config{Region: aws.String(
 
 func Server() (e *echo.Echo) {
 	e = echo.New()
+
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+	}))
 
 	e.Match([]string{http.MethodHead, http.MethodGet}, "/*", proxyHandler)
 

--- a/src/s3proxy/server.go
+++ b/src/s3proxy/server.go
@@ -1,7 +1,7 @@
 package s3proxy
 
 import (
-	"github.com/labstack/echo/v4/middleware"
+	mid "github.com/ImpactDevelopment/ImpactServer/src/middleware"
 	"net/http"
 	"net/url"
 	"time"
@@ -19,9 +19,7 @@ var AWSSession = session.Must(session.NewSession(&aws.Config{Region: aws.String(
 func Server() (e *echo.Echo) {
 	e = echo.New()
 
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
-	}))
+	e.Use(mid.Log)
 
 	e.Match([]string{http.MethodHead, http.MethodGet}, "/*", proxyHandler)
 

--- a/src/server.go
+++ b/src/server.go
@@ -58,11 +58,6 @@ func main() {
 		return nil
 	})
 
-	if os.Getenv("APP_ENV") != "HEROKU" {
-		// there is already equivalent request logging done by heroku
-		// this just spams our log files, tripling their size with duplicated data sadly
-		e.Use(middleware.Logger())
-	}
 	e.Use(middleware.Recover())
 
 	go cloudflare.PurgeIfNeeded() // "go" as a vague halfhearted attempt to make this occur only after we start listening and serving, to prevent long blocking requests

--- a/src/web/server.go
+++ b/src/web/server.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 
 	mid "github.com/ImpactDevelopment/ImpactServer/src/middleware"
@@ -9,6 +10,10 @@ import (
 
 func Server() (e *echo.Echo) {
 	e = echo.New()
+
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
+	}))
 
 	e.Match([]string{http.MethodHead, http.MethodGet}, "/changelog", changelog)
 	e.Any("/Impact/*", impactRedirect)

--- a/src/web/server.go
+++ b/src/web/server.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"github.com/labstack/echo/v4/middleware"
 	"net/http"
 
 	mid "github.com/ImpactDevelopment/ImpactServer/src/middleware"
@@ -11,9 +10,7 @@ import (
 func Server() (e *echo.Echo) {
 	e = echo.New()
 
-	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "${status} ${method} ${uri} latency=${latency_human} error=${error}\n",
-	}))
+	e.Use(mid.Log)
 
 	e.Match([]string{http.MethodHead, http.MethodGet}, "/changelog", changelog)
 	e.Any("/Impact/*", impactRedirect)


### PR DESCRIPTION
After applying the `^impcatserver heroku\/router` regex filter to papertrail, the duplicate logs issue is fixed. Therefore it's helpful to be able to configure the log output ourselves. We can for example include error messages in the log and use a sane layout such as `200 GET 200 GET /favicon-196x196.png latency=313.768µs`.

Opened as a PR to request feedback on the log format chosen and to run this by you before merging. NOTE that the papertrail filter is live currently, so pushing something else to master will deploy a branch that doesn't save any logs to papertrail!