### PR TITLE
made staff color non transparent

### DIFF
--- a/src/users/role.go
+++ b/src/users/role.go
@@ -31,7 +31,7 @@ var defaultRoleTemplates = map[string]UserInfo{
 		Cape: "https://files.impactclient.net/img/texture/staff_cape.png",
 		Editions: []Edition{{
 			Text:      "Staff",
-			TextColor: "PURPLE",
+			TextColor: "DARK_PURPLE",
 		}},
 	},
 	"pepsi": {

--- a/src/users/role.go
+++ b/src/users/role.go
@@ -31,7 +31,7 @@ var defaultRoleTemplates = map[string]UserInfo{
 		Cape: "https://files.impactclient.net/img/texture/staff_cape.png",
 		Editions: []Edition{{
 			Text:      "Staff",
-			TextColor: "#FF734EB",
+			TextColor: "PURPLE",
 		}},
 	},
 	"pepsi": {

--- a/src/users/role.go
+++ b/src/users/role.go
@@ -31,7 +31,7 @@ var defaultRoleTemplates = map[string]UserInfo{
 		Cape: "https://files.impactclient.net/img/texture/staff_cape.png",
 		Editions: []Edition{{
 			Text:      "Staff",
-			TextColor: "DARK_PURPLE",
+			TextColor: "#FF7734EB",
 		}},
 	},
 	"pepsi": {


### PR DESCRIPTION
having hex code breaks the minecraft default fontrenderer, assuming this will fix it

ttf font:
![image](https://user-images.githubusercontent.com/25800857/76235286-32959100-622b-11ea-92b7-3c48adbc4fc1.png)

mc fontrenderer
![image](https://user-images.githubusercontent.com/25800857/76235328-3fb28000-622b-11ea-83e6-91c1c8b64055.png)
