### PR TITLE
Avoid crashing when Installer download errors

### DIFF
--- a/src/web/installer.go
+++ b/src/web/installer.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -35,7 +36,7 @@ type Entry struct { // can't use zip.Entry since that seeks within the input and
 var installerEntries []Entry
 var exeHeader []byte
 
-var ready = make(chan struct{})
+var ready bool
 
 func (version InstallerVersion) getEXT() string {
 	if version == JAR {
@@ -52,13 +53,19 @@ func (version InstallerVersion) fetchFile() ([]byte, error) {
 	url := version.getURL()
 	fmt.Println("Downloading", url)
 
-	resp, err := http.Get(url)
+	request, err := util.GetRequest(url)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	response, err := request.Do()
+	if err != nil {
+		return nil, err
+	}
+	if !response.Ok() {
+		return nil, errors.New("Installer download status not OK")
+	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data := response.Body
 	fmt.Println("Finished downloading", url, "length is", len(data))
 	return data, err
 }
@@ -91,10 +98,13 @@ func init() {
 }
 
 func startup() {
-	installerJar, err := JAR.fetchFile()
-	if err != nil {
-		panic(err)
-	}
+	// Download the two files in parallel
+	jarCh := make(chan []byte)
+	exeCh := make(chan []byte)
+	go func() { jarCh <- downloadUntilSuccess(JAR, 5*time.Minute) }()
+	go func() { exeCh <- downloadUntilSuccess(EXE, 5*time.Minute) }()
+	var installerJar = <-jarCh
+	var installerExe = <-exeCh
 
 	zipReader, err := zip.NewReader(bytes.NewReader(installerJar), int64(len(installerJar)))
 	if err != nil {
@@ -118,11 +128,6 @@ func startup() {
 		})
 	}
 
-	installerExe, err := EXE.fetchFile()
-	if err != nil {
-		panic(err)
-	}
-
 	exeHeaderLen := len(installerExe) - len(installerJar)
 	for i := 0; i < len(installerJar); i++ {
 		if installerJar[i] != installerExe[exeHeaderLen+i] {
@@ -132,15 +137,20 @@ func startup() {
 	exeHeader = installerExe[:exeHeaderLen]
 
 	fmt.Println("Initialized")
-	go func() {
-		for {
-			ready <- struct{}{} // we are ready from now on
-		}
-	}()
+	ready = true // we are ready from now on
 }
 
-func awaitStartup() { // blocks and only returns once startup is done
-	<-ready
+// download the installer, if an error occurs keep trying again after duration (blocking)
+func downloadUntilSuccess(version InstallerVersion, duration time.Duration) []byte {
+	var attempts int
+	exe, err := version.fetchFile()
+	for err != nil {
+		attempts++
+		fmt.Fprintf(os.Stderr, "Error downloading %s Installer after %d attempts: %s\n", version.getEXT(), attempts, err.Error())
+		time.Sleep(duration)
+		exe, err = version.fetchFile()
+	}
+	return exe
 }
 
 func extractOrGenerateCID(c echo.Context) string {
@@ -239,12 +249,16 @@ func installer(c echo.Context, version InstallerVersion) error {
 	if installerVersion == "" {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Installer version not specified")
 	}
-	awaitStartup() // in case we get an early request, block until startup is done
 
 	referer := c.Request().Referer()
 	if referer != "" && !strings.HasPrefix(referer, util.GetServerURL().String()) && !strings.Contains(referer, "brady-money-grubbing-completed") {
 		fmt.Println("BLOCKING referer", referer)
 		return echo.NewHTTPError(http.StatusUnauthorized, "no hotlinking >:(")
+	}
+
+	if !ready {
+		c.Response().Header().Set("Retry-After", "120")
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Installer download not ready yet, please try again later")
 	}
 
 	nightlies := c.QueryParam("nightlies") == "1" || c.QueryParam("nightlies") == "true"


### PR DESCRIPTION
Instead of downloading the jar/exe and panicking if anything fails, keep trying to download every 5 mins until success.

This does mean that it's impractical to block any download requests while we do setup, because they could block for any multiple of 5mins. Instead we just respond with 503 Service Unavailable and set the Retry-After header to 120s.