### PR TITLE
Automatically distribute donation payments

### DIFF
--- a/src/stripe/client.go
+++ b/src/stripe/client.go
@@ -154,7 +154,7 @@ func GetCurrencyMap() map[string]CurrencyInfo {
 
 // DistributeDonation splits a payment evenly between the cached connected accounts
 // Any leftovers remain in the Impact stripe account
-func DistributeDonation(payment stripe.PaymentIntent) error {
+func DistributeDonation(payment *stripe.PaymentIntent) error {
 	accountsLock.Lock()
 	defer accountsLock.Unlock()
 

--- a/src/stripe/client.go
+++ b/src/stripe/client.go
@@ -2,21 +2,52 @@ package stripe
 
 import (
 	"errors"
+	"fmt"
+	"github.com/ImpactDevelopment/ImpactServer/src/util"
 	"github.com/labstack/echo/v4"
 	"github.com/stripe/stripe-go/v71"
+	"github.com/stripe/stripe-go/v71/account"
 	"github.com/stripe/stripe-go/v71/paymentintent"
+	"github.com/stripe/stripe-go/v71/transfer"
 	"github.com/stripe/stripe-go/v71/webhook"
 	"net/http"
 	"os"
+	"sync"
+	"time"
 )
 
 var PublicKey string
 var webhookSecret string
 
+// A list of accounts to distribute donations to
+// TODO combine mutex lock & slice into one strut
+var connectedAccounts []stripe.Account
+var accountsLock sync.Mutex
+
 func init() {
+	// Set values from environment
 	PublicKey = os.Getenv("STRIPE_PUBLIC_KEY")
 	stripe.Key = os.Getenv("STRIPE_PRIVATE_KEY")
 	webhookSecret = os.Getenv("STRIPE_WEBHOOK_SECRET")
+
+	// Fetch connected accounts
+	var err error
+	connectedAccounts, err = getConnectedAccounts()
+	if err != nil {
+		println("Error fetching Stripe connected accounts: ", err.Error())
+	} else {
+		util.DoRepeatedly(time.Hour, func() {
+			accountsLock.Lock()
+			defer accountsLock.Unlock()
+
+			accounts, err := getConnectedAccounts()
+			if err != nil {
+				println("Error updating Stripe connected accounts: ", err.Error())
+			}
+
+			connectedAccounts = accounts
+		})
+	}
 }
 
 type Payment struct {
@@ -119,4 +150,89 @@ func GetCurrencyInfo(currency string) (*CurrencyInfo, error) {
 
 func GetCurrencyMap() map[string]CurrencyInfo {
 	return stripeCurrencyMap
+}
+
+// DistributeDonation splits a payment evenly between the cached connected accounts
+// Any leftovers remain in the Impact stripe account
+func DistributeDonation(payment stripe.PaymentIntent) error {
+	accountsLock.Lock()
+	defer accountsLock.Unlock()
+
+	// Get charge id
+	// There should only be one charge
+	var chargeID *string
+	for _, charge := range payment.Charges.Data {
+		chargeID = &charge.ID
+		break
+	}
+	if chargeID == nil {
+		return fmt.Errorf("unable to get charge ID for payment %s\n", payment.ID)
+	}
+
+	// Calculate the value of each share
+	shares := len(connectedAccounts)
+	if shares < 1 {
+		return errors.New("unable to distribute shares, zero shareholders")
+	}
+
+	// TODO get the target leftover amount from env?
+	const targetLeftover = 50
+	amount := payment.Amount
+	share := (amount - targetLeftover) / int64(shares)
+	leftover := amount - share*int64(shares)
+
+	// Don't transfer negative values 😂
+	if share <= 0 {
+		return fmt.Errorf("calculated share (%.2f %s)is less than zero", float64(share)/100, payment.Currency)
+	}
+
+	// FIXME remove this debugging code?
+	fmt.Printf("Distributing %d shares of %.2f %s, with a leftover of %.2f %s\n", shares, float64(share)/100, payment.Currency, float64(leftover)/100, payment.Currency)
+
+	// Distribute the shares
+	// Keep track of created transfers so we can verify they were all created successfully
+	var transfers []stripe.Transfer
+	for _, acct := range connectedAccounts {
+
+		// Do the transfer
+		t, err := transfer.New(&stripe.TransferParams{
+			Amount:            stripe.Int64(share),
+			Currency:          stripe.String(payment.Currency),
+			Destination:       stripe.String(acct.ID),
+			SourceTransaction: chargeID,
+		})
+
+		if err == nil {
+			transfers = append(transfers, *t)
+		} else {
+			fmt.Printf("Error distributing %.2f %s to %s\n", float64(share)/100, payment.Currency, acct.Email)
+		}
+	}
+
+	// Sanity check
+	//TODO is this really necessary? If it is, should we attempt to reverse successful transfers when some fail?
+	if len(transfers) != shares {
+		return fmt.Errorf("not all transfers were created successfully, %d succeeded out of %d", len(transfers), shares)
+	}
+
+	return nil
+}
+
+// getConnectedAccounts returns a list of up to 10 connected accounts
+func getConnectedAccounts() ([]stripe.Account, error) {
+	// Fetch up to 10 connected accounts
+	params := &stripe.AccountListParams{}
+	params.Filters.AddFilter("limit", "", "10")
+	iter := account.List(params)
+	if iter.Err() != nil {
+		return nil, iter.Err()
+	}
+
+	// Copy accounts to a new slice
+	var accounts []stripe.Account
+	for iter.Next() {
+		accounts = append(accounts, *iter.Account())
+	}
+
+	return accounts, nil
 }


### PR DESCRIPTION
This PR aims to automatically split each donation between our Express accounts - i.e. the ones connected to Impact's Stripe account.

On init and again every hour, the server will fetch a list of Connected accounts - these accounts could be Express accounts, full/standard stripe accounts that have connected with us, or custom accounts that are fully managed by us. A mutex is locked while doing this to prevent DistrubuteDonation() from doing anything while updating the list.

On payment success, the server will transfer an even share to every connected account. A target leftover of $0.50 is deducted before calculating shares, and any leftovers (i.e. the $0.50 plus any remainders from division) will be left in the main Impact stripe account's balance.

This is tested as working, or at least DistributeDonation() and stripe/client.go's init() function are tested - I haven't actually tested changes to the payment success webhook, but they are extremely trivial.

I used the following within `init()` to test:

```go
	//FIXME TEST CODE
	pi, _ := paymentintent.Get("pi_<redacted-id>", nil)
	DistributeDonation(pi)
```

The following snippet can be used to "backport" the payment distribution one time before merging:
```go
	var blacklist = []string{
		"pi_<redacted>",
	}
	params := &stripe.PaymentIntentListParams{}
	params.Filters.AddFilter("status", "", "paid")
	iter := paymentintent.List(params)
	main: for iter.Next() {
		payment := iter.PaymentIntent()
		
		// Scan the blacklist
		for _, ignore := range blacklist {
			if payment.ID == ignore {
				continue main
			}
		}
		
		// Not blacklisted, so distribute the payment
		err := DistributeDonation(payment)
		if err != nil {
			fmt.Printf("Error distributing payment %s: %s\n", payment.ID, err.Error())
		}
	}
```
The `blacklist` should contain PaymentIntent IDs for any payment that's already been distributed - e.g. for testing purposes.